### PR TITLE
Prevent hover action when disabled

### DIFF
--- a/new.css
+++ b/new.css
@@ -239,15 +239,15 @@ input[type="button"][disabled] {
 }
 
 .button:focus,
-.button:hover,
+.button:enabled:hover,
 button:focus,
-button:hover,
+button:enabled:hover,
 input[type="submit"]:focus,
-input[type="submit"]:hover,
+input[type="submit"]:enabled:hover,
 input[type="reset"]:focus,
-input[type="reset"]:hover,
+input[type="reset"]:enabled:hover,
 input[type="button"]:focus,
-input[type="button"]:hover {
+input[type="button"]:enabled:hover {
 	background: var(--nc-lk-2);
 }
 


### PR DESCRIPTION
## Summary

I made the hover action only when enabled. Because if there is a hover action when disabled, an affordance that expects to be pressed will occur.

## Screenshot

|  before  |  after  |
| ---- | ---- |
| ![before-output](https://user-images.githubusercontent.com/8067736/83322400-44b72680-a292-11ea-8114-c18ae47d5afb.gif)  |  ![after-output](https://user-images.githubusercontent.com/8067736/83322408-4e408e80-a292-11ea-8a5f-6fc54eaffdcb.gif)  |
