### PR TITLE
Remove bottom margin on clickable images

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -207,7 +207,7 @@
     <img src="https://elements.xz.style/assets/fuji-daniel-hehn.jpg" alt="Mt. Fuji">
 
     <p>
-        Image inline: <a href="/"><img src="https://elements.xz.style/assets/fuji-daniel-hehn.jpg" width="50" alt="Mt. Fuji"></a>
+        Inline image: <a href="#"><img src="https://elements.xz.style/assets/fuji-daniel-hehn.jpg" width="50" alt="Mt. Fuji"></a>
     </p>
 
     <script async defer src="https://api.newcss.net/latest.js"></script>

--- a/demo.html
+++ b/demo.html
@@ -206,6 +206,10 @@
 
     <img src="https://elements.xz.style/assets/fuji-daniel-hehn.jpg" alt="Mt. Fuji">
 
+    <p>
+        Image inline: <a href="/"><img src="https://elements.xz.style/assets/fuji-daniel-hehn.jpg" width="50" alt="Mt. Fuji"></a>
+    </p>
+
     <script async defer src="https://api.newcss.net/latest.js"></script>
     <noscript><img src="https://api.newcss.net/noscript.gif" alt=""></noscript>
 </body>

--- a/new.css
+++ b/new.css
@@ -265,6 +265,10 @@ input[type="button"]:enabled:hover {
 	background: var(--nc-lk-2);
 }
 
+a img {
+	margin-bottom: 0px;
+}
+
 code,
 pre,
 kbd,


### PR DESCRIPTION
Here is current rule applied to `img`:

```css
img {
	/* Margins for most elements */
	margin-bottom: 1rem;
}
```

A clickable image appeared with an empty space below it:

> ![image](https://user-images.githubusercontent.com/2071331/102476443-62e04a80-405b-11eb-8aec-08c6fdf5c566.png)

So I added a rule to prevent this.