### PR TITLE
Light mode: --nc-bg-2 is now darker.

### DIFF
--- a/new.css
+++ b/new.css
@@ -6,7 +6,7 @@
 	--nc-tx-1: #000000;
 	--nc-tx-2: #1A1A1A;
 	--nc-bg-1: #FFFFFF;
-	--nc-bg-2: #F6F8FA;
+	--nc-bg-2: #EFF0F1;
 	--nc-bg-3: #E5E7EB;
 	--nc-lk-1: #0070F3;
 	--nc-lk-2: #0366D6;


### PR DESCRIPTION
This is done to make `<blockquote>`, `<code>` as well as many other tags' background easier to see.

Fixes #58 