### PR TITLE
Heading border removed to avoid letter collisions

### DIFF
--- a/new.css
+++ b/new.css
@@ -120,9 +120,7 @@ h1,
 h2,
 h3 {
 	color: var(--nc-tx-1);
-	padding-bottom: 2px;
 	margin-bottom: 8px;
-	border-bottom: 1px solid var(--nc-bg-2);
 }
 
 h4,


### PR DESCRIPTION
Heading border removed. Issue described in https://github.com/xz/new.css/issues/64.