### PR TITLE
Fix padding on input of type range

### DIFF
--- a/new.css
+++ b/new.css
@@ -431,7 +431,7 @@ mark {
 
 textarea,
 select,
-input {
+input:not([type='range]) {
 	padding: 6px 12px;
 	margin-bottom: .5rem;
 	background: var(--nc-bg-2);


### PR DESCRIPTION
Closes #40 

Leaves all inputs with the same padding except for those with type == range, which will now have no padding as expected.

Not only is the issue in #40 a problem, but also that the min on the range will never be at the left-most border, nor will the max value be at the right-most border, which I'd argue is expected behavior.