### PR TITLE
Don't remove margin & padding for `:last-child`s deep inside blockquote

### DIFF
--- a/new.css
+++ b/new.css
@@ -178,7 +178,7 @@ abbr {
 	cursor: help;
 }
 
-blockquote *:last-child {
+blockquote > *:last-child {
 	padding-bottom: 0;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
This selector should be more similar to that of the analogous css rule for `header` (`header > *:last-child { margin-bottom: 0; }`)