### PR TITLE
feat: added accent color at supported elements

### DIFF
--- a/new.css
+++ b/new.css
@@ -449,3 +449,10 @@ input {
 img {
 	max-width: 100%;
 }
+
+input[type="checkbox"],
+input[type="radio"],
+input[type="range"],
+progress {
+	accent-color: var(--nc-ac-1);
+}


### PR DESCRIPTION
Added `accent-color` property to supported elements (based on [mdn docs](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color))

This pull request is related to #78 issue.