### PR TITLE
Change readme to recommend loading font from a CDN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this line to the end of your HTML's `<head>`:
 If you'd like the font [Inter](https://rsms.me/inter) as well (recommended), add this line as well:
 
 ```html
-<link rel="stylesheet" href="https://fonts.xz.style/serve/inter.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/open-fonts@1.1.1/fonts/inter.min.css">
 ```
 
 ### npm


### PR DESCRIPTION
The readme previously recommended loading the Inter font from fonts.xyz.style, which sets `max-age=0` in the Cache-Control header. This causes the font to be reloaded from the server on every page hit, which results in an ugly Flash of Unstyled Text (FOUT) in Chrome.

By loading the font from the jsdelivr CDN, the FOUT is almost completely eliminated because jsdelivr sets max-age to a high value and allows the browser to cache the font.

Note that the new.css demo page at https://newcss.net/ uses jsdelivr for the font.